### PR TITLE
Create dev-M1.txt

### DIFF
--- a/.requirements/dev-M1.txt
+++ b/.requirements/dev-M1.txt
@@ -1,0 +1,8 @@
+deepdiff>=5.0
+gsutil>=4.60
+keras-tuner>=1.0.2
+matplotlib>=3.3
+pytest>=6.1.2
+questionary>=1.8.1
+scikit-learn>=0.24.1
+wandb>=0.12.1


### PR DESCRIPTION
 To install the tensorflow for Mac OS 
```zsh
conda install -c apple tensorflow-deps
python -m pip install tensorflow-macos
python -m pip install tensorflow-metal
```

The `.requirements/dev-M1.txt`
```txt
deepdiff>=5.0
gsutil>=4.60
keras-tuner>=1.0.2
matplotlib>=3.3
pytest>=6.1.2
questionary>=1.8.1
scikit-learn>=0.24.1
wandb>=0.12.1
```

We need to install some packages separately.
```zsh
conda install numpy
conda install openblas #to fix the numpy
conda install healpy
conda install pandas
```